### PR TITLE
feat: add kratos boilerplate behind feature flag

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -11,5 +11,8 @@
 
   "SESSION_KEYS": "sessionkeys",
 
-  "AUTH_ENDPOINT": "http://localhost:3000/api/login"
+  "AUTH_ENDPOINT": "http://localhost:3000/api/login",
+  "AUTH_BASE_URL": "http://localhost:3000/api",
+  "KRATOS_API_BASE_URL": "http://localhost:4433/",
+  "KRATOS_BROWSER_URL": "http://localhost:4433/"
 }

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -69,7 +69,7 @@ module.exports = {
     "init-declarations": "error",
     "jsx-quotes": "error",
     "linebreak-style": ["error", "unix"],
-    "max-depth": ["error", { max: 3 }],
+    "max-depth": ["error", { max: 4 }],
     "max-lines-per-function": ["error", { max: 500 }],
     "max-lines": ["error", { max: 500 }],
     "max-nested-callbacks": ["error", { max: 3 }],

--- a/dev/email-schema.json
+++ b/dev/email-schema.json
@@ -1,0 +1,34 @@
+{
+  "$id": "https://schemas.ory.sh/presets/kratos/quickstart/email-password/identity.schema.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Person",
+  "type": "object",
+  "properties": {
+    "traits": {
+      "type": "object",
+      "properties": {
+        "email": {
+          "type": "string",
+          "format": "email",
+          "title": "E-Mail",
+          "minLength": 3,
+          "ory.sh/kratos": {
+            "credentials": {
+              "password": {
+                "identifier": true
+              }
+            },
+            "verification": {
+              "via": "email"
+            },
+            "recovery": {
+              "via": "email"
+            }
+          }
+        }
+      },
+      "required": ["email"],
+      "additionalProperties": false
+    }
+  }
+}

--- a/dev/kratos.yml
+++ b/dev/kratos.yml
@@ -1,0 +1,80 @@
+version: v0.8.2-alpha.1
+
+dsn: memory
+
+serve:
+  public:
+    base_url: http://localhost:4433/
+    cors:
+      enabled: true
+  admin:
+    base_url: http://kratos:4434/
+
+selfservice:
+  default_browser_return_url: http://localhost:3000/
+  whitelisted_return_urls:
+    - http://localhost:3000
+
+  methods:
+    password:
+      enabled: true
+
+  flows:
+    error:
+      ui_url: http://localhost:4455/error
+
+    settings:
+      ui_url: http://localhost:4455/settings
+      privileged_session_max_age: 15m
+
+    recovery:
+      enabled: true
+      ui_url: http://localhost:4455/recovery
+
+    verification:
+      enabled: true
+      ui_url: http://localhost:4455/verification
+      after:
+        default_browser_return_url: http://localhost:4455/
+
+    logout:
+      after:
+        default_browser_return_url: http://localhost:4455/login
+
+    login:
+      ui_url: http://localhost:4455/login
+      lifespan: 10m
+
+    registration:
+      lifespan: 10m
+      ui_url: http://localhost:3000/register/email
+      after:
+        password:
+          hooks:
+            - hook: session
+
+log:
+  level: debug
+  format: text
+  leak_sensitive_values: true
+
+secrets:
+  cookie:
+    - PLEASE-CHANGE-ME-I-AM-VERY-INSECURE
+  cipher:
+    - 32-LONG-SECRET-NOT-SECURE-AT-ALL
+
+ciphers:
+  algorithm: xchacha20-poly1305
+
+hashers:
+  algorithm: bcrypt
+  bcrypt:
+    cost: 8
+
+identity:
+  default_schema_url: file:///etc/config/kratos/identity.schema.json
+
+courier:
+  smtp:
+    connection_uri: smtps://test:test@mailslurper:1025/?skip_ssl_verify=true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,62 @@
+version: "3.7"
+
+services:
+  kratos-migrate:
+    image: oryd/kratos:v0.8.2-alpha.1
+    depends_on:
+      - postgres
+    environment:
+      - DSN=postgres://kratos:secret@postgres:5432/kratos?sslmode=disable&max_conns=20&max_idle_conns=4
+    command: -c /etc/config/kratos/kratos.yml migrate sql -e --yes
+    restart: on-failure
+    volumes:
+      - type: bind
+        source: ./dev/kratos.yml
+        target: /etc/config/kratos/kratos.yml
+      - type: bind
+        source: ./dev/email-schema.json
+        target: /etc/config/kratos/identity.schema.json
+    networks:
+      - intranet
+
+  kratos:
+    image: oryd/kratos:v0.8.2-alpha.1
+    command: serve -c /etc/config/kratos/kratos.yml --dev --watch-courier
+    depends_on:
+      - postgres
+    volumes:
+      - type: bind
+        source: ./dev/kratos.yml
+        target: /etc/config/kratos/kratos.yml
+      - type: bind
+        source: ./dev/email-schema.json
+        target: /etc/config/kratos/identity.schema.json
+    environment:
+      - DSN=postgres://kratos:secret@postgres:5432/kratos?sslmode=disable&max_conns=20&max_idle_conns=4
+    ports:
+      - "4433:4433" # public
+      - "4434:4434" # admin
+    networks:
+      - intranet
+
+  postgres:
+    image: postgres:9.6
+    ports:
+      - "5432:5432"
+    environment:
+      - POSTGRES_USER=kratos
+      - POSTGRES_PASSWORD=secret
+      - POSTGRES_DB=kratos
+    networks:
+      - intranet
+
+  mailslurper:
+    image: oryd/mailslurper:latest-smtps
+    ports:
+      - "4436:4436"
+      - "4437:4437"
+    networks:
+      - intranet
+
+networks:
+  intranet:

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
   "dependencies": {
     "@galoymoney/client": "^0.0.21",
     "@galoymoney/react": "^0.0.15",
+    "@ory/client": "^0.0.1-alpha.49",
+    "@ory/kratos-client": "^0.8.2-alpha.1",
     "@testing-library/jest-dom": "^5.16.2",
     "@testing-library/react": "^12.1.2",
     "@testing-library/user-event": "^13.5.0",

--- a/src/components/pages/register.tsx
+++ b/src/components/pages/register.tsx
@@ -1,0 +1,16 @@
+import { SelfServiceRegistrationFlow } from "@ory/kratos-client"
+import { useState } from "react"
+
+interface RegisterProps {
+  flowData?: KratosFlowData
+}
+
+const Register = ({ flowData: flowDataProp }: RegisterProps) => {
+  const [flowData] = useState<SelfServiceRegistrationFlow | undefined>(
+    flowDataProp?.registrationData,
+  )
+
+  return <div className="register">{JSON.stringify(flowData)}</div>
+}
+
+export default Register

--- a/src/components/root-component.tsx
+++ b/src/components/root-component.tsx
@@ -1,40 +1,64 @@
+import { kratosFeatureFlag } from "../kratos"
 import { Suspense } from "react"
 import { ErrorBoundary } from "react-error-boundary"
 
 import { Spinner } from "@galoymoney/react"
 
-import appRoutes, { checkRoute } from "../server/routes"
+import { appRoutes, checkRoute, authRoutes, checkAuthRoute } from "../server/routes"
 
 import ErrorFallback from "./error-fallback"
 
 type Props = {
   path: RoutePath
+  flowData?: KratosFlowData
   [name: string]: unknown
 }
 
-const RootComponent = ({ path, ...props }: Props) => {
+const RootComponent = ({ path, flowData, ...props }: Props) => {
   const checkedRoutePath = checkRoute(path)
-  if (checkedRoutePath instanceof Error) {
-    throw checkedRoutePath
+  if (!(checkedRoutePath instanceof Error)) {
+    const Component = appRoutes[checkedRoutePath].component
+
+    return (
+      <Suspense
+        fallback={
+          <div className="suspense-fallback">
+            <Spinner size="big" />
+          </div>
+        }
+      >
+        <ErrorBoundary FallbackComponent={ErrorFallback}>
+          <div id="main-container">
+            <Component {...props} />
+          </div>
+        </ErrorBoundary>
+      </Suspense>
+    )
+  }
+  if (kratosFeatureFlag) {
+    const checkedAuthRoutePath = checkAuthRoute(path)
+    if (!(checkedAuthRoutePath instanceof Error)) {
+      const Component = authRoutes[checkedAuthRoutePath].component
+
+      return (
+        <Suspense
+          fallback={
+            <div className="suspense-fallback">
+              <Spinner size="big" />
+            </div>
+          }
+        >
+          <ErrorBoundary FallbackComponent={ErrorFallback}>
+            <div id="main-container">
+              <Component flowData={flowData} />
+            </div>
+          </ErrorBoundary>
+        </Suspense>
+      )
+    }
   }
 
-  const Component = appRoutes[checkedRoutePath].component
-
-  return (
-    <Suspense
-      fallback={
-        <div className="suspense-fallback">
-          <Spinner size="big" />
-        </div>
-      }
-    >
-      <ErrorBoundary FallbackComponent={ErrorFallback}>
-        <div id="main-container">
-          <Component {...props} />
-        </div>
-      </ErrorBoundary>
-    </Suspense>
-  )
+  throw checkedRoutePath
 }
 
 export default RootComponent

--- a/src/components/root-component.tsx
+++ b/src/components/root-component.tsx
@@ -50,7 +50,7 @@ const RootComponent = ({ path, flowData, ...props }: Props) => {
         >
           <ErrorBoundary FallbackComponent={ErrorFallback}>
             <div id="main-container">
-              <Component flowData={flowData} />
+              <Component flowData={flowData} {...props} />
             </div>
           </ErrorBoundary>
         </Suspense>

--- a/src/components/root.tsx
+++ b/src/components/root.tsx
@@ -33,7 +33,12 @@ const Root = ({ GwwState }: RootProps) => {
   return (
     <AuthProvider>
       <GwwContext.Provider value={{ state, dispatch }}>
-        <RootComponent path={state.path} key={state.key} {...state.props} />
+        <RootComponent
+          path={state.path}
+          key={state.key}
+          flowData={state.flowData}
+          {...state.props}
+        />
       </GwwContext.Provider>
     </AuthProvider>
   )
@@ -43,6 +48,7 @@ type SSRootProps = {
   client: GaloyClient<unknown>
   galoyJwtToken?: string
   GwwState: GwwState
+  flowData?: KratosFlowData
 }
 
 export const SSRRoot = ({ client, GwwState, galoyJwtToken }: SSRootProps) => {
@@ -54,7 +60,7 @@ export const SSRRoot = ({ client, GwwState, galoyJwtToken }: SSRootProps) => {
   return (
     <AuthProvider galoyClient={client} galoyJwtToken={galoyJwtToken}>
       <GwwContext.Provider value={{ state, dispatch }}>
-        <RootComponent path={state.path} {...state.props} />
+        <RootComponent path={state.path} flowData={state.flowData} {...state.props} />
       </GwwContext.Provider>
     </AuthProvider>
   )

--- a/src/kratos/config.ts
+++ b/src/kratos/config.ts
@@ -1,0 +1,12 @@
+import { Configuration } from "@ory/client"
+import { V0alpha2ApiInterface, V0alpha2Api } from "@ory/kratos-client"
+
+const kratosApiBaseUrlInternal = process.env.KRATOS_API_BASE_URL as string
+
+export const kratosBrowserUrl = process.env.KRATOS_BROWSER_URL as string
+
+export const kratosFeatureFlag = Boolean(process.env.KRATOS_FEATURE_FLAG || false)
+
+export const kratosSdk: V0alpha2ApiInterface = new V0alpha2Api(
+  new Configuration({ basePath: kratosApiBaseUrlInternal }),
+) as unknown as V0alpha2ApiInterface

--- a/src/kratos/handler.ts
+++ b/src/kratos/handler.ts
@@ -1,0 +1,42 @@
+/* eslint-disable camelcase */
+
+import { SelfServiceRegistrationFlow } from "@ory/kratos-client"
+import { Request } from "express"
+import { getUrlForFlow, isQuerySet } from "./helpers"
+import { kratosSdk } from "./config"
+
+export const handleRegister = async (req: Request): Promise<HandleRegisterResponse> => {
+  const { flow, return_to = "" } = req.query
+
+  const initFlowUrl = getUrlForFlow(
+    "registration",
+    new URLSearchParams({ return_to: return_to.toString() }),
+  )
+
+  // The flow is used to identify the settings and registration flow and
+  // return data like the csrf_token and so on.
+  if (!isQuerySet(flow)) {
+    return { redirect: true, redirectTo: initFlowUrl }
+  }
+
+  try {
+    const { data }: { data: SelfServiceRegistrationFlow } =
+      await kratosSdk.getSelfServiceRegistrationFlow(flow, req.header("Cookie"))
+    return { redirect: false, flowData: { registrationData: data } }
+  } catch (error: any) {
+    switch (error?.response?.status) {
+      // Flow ID is old
+      case 410:
+      case 404: {
+        return { redirect: true, redirectTo: initFlowUrl }
+      }
+      default: {
+        console.log("Error while fetching registration flow", {
+          error,
+          flow,
+        })
+        throw error
+      }
+    }
+  }
+}

--- a/src/kratos/helpers.ts
+++ b/src/kratos/helpers.ts
@@ -1,0 +1,10 @@
+import { kratosBrowserUrl } from "./config"
+
+export const isQuerySet = (query: any): query is string =>
+  typeof query === "string" && query.length > 0
+const removeTrailingSlash = (str: string) => str.replace(/\/$/u, "")
+
+export const getUrlForFlow = (flow: string, query?: URLSearchParams) =>
+  `${removeTrailingSlash(kratosBrowserUrl)}/self-service/${flow}/browser${
+    query ? `?${query.toString()}` : ""
+  }`

--- a/src/kratos/index.ts
+++ b/src/kratos/index.ts
@@ -1,0 +1,2 @@
+export * from "./config"
+export * from "./handler"

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -7,7 +7,7 @@ import Transactions from "../components/pages/transactions"
 
 // Note: The component property is skipped by the serialize function
 // It's only used on the front-end
-const appRoutes = {
+const appRoutesDef = {
   "/": {
     component: Home,
     title: "Galoy Web Wallet",
@@ -38,14 +38,7 @@ const appRoutes = {
   },
 }
 
-export type SupportedRoutes = keyof typeof appRoutes
-
-export const checkRoute = (path: string): RoutePath | Error => {
-  if (appRoutes[path as never]) {
-    return path as RoutePath
-  }
-  return new Error("Invaild route path")
-}
+export type SupportedRoutes = keyof typeof appRoutesDef
 
 type AppRoutes = Record<
   RoutePath,
@@ -54,5 +47,39 @@ type AppRoutes = Record<
     title: string
   }
 >
+export const appRoutes: AppRoutes = appRoutesDef as unknown as AppRoutes
 
-export default appRoutes as unknown as AppRoutes
+export const checkRoute = (path: string): RoutePath | Error => {
+  if (appRoutes[path as never]) {
+    return path as RoutePath
+  }
+  return new Error("Invaild route path")
+}
+
+import Register from "../components/pages/register"
+
+const authRoutesDef = {
+  "/register/email": {
+    component: Register,
+    title: "Register with Email",
+  },
+}
+
+export type SupportedAuthRoutes = keyof typeof authRoutesDef
+
+export const checkAuthRoute = (path: string): AuthRoutePath | Error => {
+  if (authRoutesDef[path as never]) {
+    return path as AuthRoutePath
+  }
+  return new Error("Invaild auth route path")
+}
+
+type AuthRoutes = Record<
+  AuthRoutePath,
+  {
+    component: (props: { flowData?: KratosFlowData }) => JSX.Element
+    title: string
+  }
+>
+
+export const authRoutes: AuthRoutes = authRoutesDef

--- a/src/store/config.ts
+++ b/src/store/config.ts
@@ -10,6 +10,9 @@ if (!isBrowser) {
     "GRAPHQL_URI",
     "GRAPHQL_SUBSCRIPTION_URI",
     "AUTH_ENDPOINT",
+    "AUTH_BASE_URL",
+    "KRATOS_API_BASE_URL",
+    "KRATOS_BROWSER_URL",
   ]
 
   requiredEnvVars.forEach((envVar) => {
@@ -46,6 +49,7 @@ const config = isBrowser
       graphqlUri: window.__G_DATA.GwwConfig.graphqlUri,
       graphqlSubscriptionUri: window.__G_DATA.GwwConfig.graphqlSubscriptionUri,
       authEndpoint: window.__G_DATA.GwwConfig.authEndpoint,
+      kratosFeatureFlag: window.__G_DATA.GwwConfig.kratosFeatureFlag,
       sessionKeys: "",
     }
   : {
@@ -61,6 +65,7 @@ const config = isBrowser
       graphqlSubscriptionUri: process.env.GRAPHQL_SUBSCRIPTION_URI as string,
 
       authEndpoint: process.env.AUTH_ENDPOINT as string,
+      kratosFeatureFlag: Boolean(process.env.KRATOS_FEATURE_FLAG || false),
     }
 
 export default config

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -17,11 +17,22 @@ type AtLeast<T, K extends keyof T> = Partial<T> & Pick<T, K>
 type RoutePath = import("../server/routes").SupportedRoutes
 type RouteInfo = Record<string, string | (() => JSX.Element | null)>
 
+type KratosFlowData = { registrationData?: SelfServiceRegistrationFlow }
+type AuthRoutePath = typeof import("../server/routes").SupportedAuthRoutes
+
+type HandleRegisterResponse =
+  | {
+      redirect: true
+      redirectTo: string
+    }
+  | { redirect: false; flowData: KratosFlowData }
+
 type GwwState = {
-  path: RoutePath
+  path: RoutePath | AuthRoutePath
   props?: Record<string, unknown>
   key: number
   defaultLanguage?: string
+  flowData?: KratosFlowData
 }
 
 type GwwAction = {
@@ -60,6 +71,7 @@ declare interface Window {
       graphqlSubscriptionUri: string
       network: Network
       authEndpoint: string
+      kratosFeatureFlag: boolean
     }
   }
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/types/libs.d.ts
+++ b/src/types/libs.d.ts
@@ -1,2 +1,3 @@
 import {} from "react/next"
 import {} from "react-dom/next"
+import {} from "@ory/kratos-client"

--- a/yarn.lock
+++ b/yarn.lock
@@ -620,6 +620,20 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
+"@ory/client@^0.0.1-alpha.49":
+  version "0.0.1-alpha.89"
+  resolved "https://registry.yarnpkg.com/@ory/client/-/client-0.0.1-alpha.89.tgz#f3bc6bb33d5dbc23a3a98d270a82e6f2319185e4"
+  integrity sha512-nhWrkh0/eW4QDdssoUWXEMjdWAaKvHjQF9EbZhUeTr1ey97myb0YHCzplKG3BAUo6pt3DbS6WLgSsg/Dr7sFpg==
+  dependencies:
+    axios "^0.21.4"
+
+"@ory/kratos-client@^0.8.2-alpha.1":
+  version "0.8.2-alpha.1"
+  resolved "https://registry.yarnpkg.com/@ory/kratos-client/-/kratos-client-0.8.2-alpha.1.tgz#35d9fba198c768bb7e1a39587494d1e2b3fe4780"
+  integrity sha512-Mh5MiZb0nLt1+SvhgbOLVSSzksgunX5PC2kQX8D8viGwa7yfp3l4gt73NHo0P66t91Vmou3yryyxJGA6HKx9Zw==
+  dependencies:
+    axios "^0.21.1"
+
 "@sinonjs/commons@^1.7.0":
   version "1.8.3"
   resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.8.3.tgz#3802ddd21a50a949b6721ddd72da36e67e7f1b2d"
@@ -1481,7 +1495,7 @@ awilix@^4.2.7:
     camel-case "^4.1.2"
     glob "^7.1.6"
 
-axios@^0.21.0:
+axios@^0.21.0, axios@^0.21.1, axios@^0.21.4:
   version "0.21.4"
   resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.4.tgz#c67b90dc0568e5c1cf2b0b858c43ba28e2eda575"
   integrity sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==


### PR DESCRIPTION
Here is some more boilerplate on how to pass the `flowData` that we get from Kratos into the view (works both SSR and DOM rendered).

Its exposed behind a feature flag that is off by default. This is not intended to be functional at this point - but I'd like to merge / get feedback on the basic structure.

If this pattern is alright I can continue by populating the register view form and creating the other flows.