### PR TITLE
docs: update webserver log to a hyperlink

### DIFF
--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -58,5 +58,5 @@ app.use("/api", apiRouter)
 app.use("/", ssrRouter)
 
 app.listen(config.port as number, config.host as string, () => {
-  console.info(`Running on ${config.host}:${config.port}...`)
+  console.info(`Running on http://${config.host}:${config.port}...`)
 })


### PR DESCRIPTION
A small improvement to make the webserver log clickable, a nice shortcut to use during development.

<img width="216" alt="Screen Shot 2022-11-11 at 6 04 18 PM" src="https://user-images.githubusercontent.com/14062229/201446126-9d98f590-b016-404c-b5b7-9a87dc67e18c.png">
