### PR TITLE
fix: login redirect loop

### DIFF
--- a/src/components/auth-provider.tsx
+++ b/src/components/auth-provider.tsx
@@ -94,7 +94,7 @@ export const AuthProvider: FCT = ({ children, galoyClient, authIdentity }) => {
           }).finally(() => {
             localStorage.clear()
             sessionStorage.clear()
-            if (!window.location.pathname.includes("login")){
+            if (!window.location.pathname.includes("login")) {
               window.location.replace("/login")
             }
           })

--- a/src/components/auth-provider.tsx
+++ b/src/components/auth-provider.tsx
@@ -91,10 +91,12 @@ export const AuthProvider: FCT = ({ children, galoyClient, authIdentity }) => {
             method: "GET",
             redirect: "follow",
             credentials: "include",
-          }).then(() => {
+          }).finally(() => {
             localStorage.clear()
             sessionStorage.clear()
-            window.location.replace("/login")
+            if (!window.location.pathname.includes("login")){
+              window.location.replace("/login")
+            }
           })
         }
         if (graphQLErrors) {

--- a/src/components/logout-link.tsx
+++ b/src/components/logout-link.tsx
@@ -19,7 +19,7 @@ const LogoutLink: NoPropsFCT = () => {
         credentials: "include",
       })
       localStorage.clear()
-      if (!window.location.pathname.includes("login")){
+      if (!window.location.pathname.includes("login")) {
         window.location.href = "/logout"
       }
     })

--- a/src/components/logout-link.tsx
+++ b/src/components/logout-link.tsx
@@ -19,7 +19,9 @@ const LogoutLink: NoPropsFCT = () => {
         credentials: "include",
       })
       localStorage.clear()
-      window.location.href = "/logout"
+      if (!window.location.pathname.includes("login")){
+        window.location.href = "/logout"
+      }
     })
   }
 

--- a/src/components/logout-link.tsx
+++ b/src/components/logout-link.tsx
@@ -19,9 +19,7 @@ const LogoutLink: NoPropsFCT = () => {
         credentials: "include",
       })
       localStorage.clear()
-      if (!window.location.pathname.includes("login")) {
-        window.location.href = "/logout"
-      }
+      window.location.href = "/logout"
     })
   }
 


### PR DESCRIPTION
There is an edge case when you visit `https://galoy.io` (marketing site) then visit `https://wallet.mainnet.galoy.io` the browser saves the cookies from the top level domain.  If the kratos auth cookies are expired it causes a redirect loop to the login page. This patch should fix that.